### PR TITLE
Fixed missing import in sample as well as added index + "typo" fix

### DIFF
--- a/examples/save_image.py
+++ b/examples/save_image.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     edsdk.OpenSession(cam)
     edsdk.SetObjectEventHandler(cam, ObjectEvent.All, callback_object)
     edsdk.SetPropertyData(cam, PropID.SaveTo, 0, SaveTo.Host)
-    print(edsdk.GetPropertyData(cam, PropID.SaveTo))
+    print(edsdk.GetPropertyData(cam, PropID.SaveTo, 0))
 
     # Sets (Computer's) Capacity to an arbitrary big value
     edsdk.SetCapacity(

--- a/examples/save_image.py
+++ b/examples/save_image.py
@@ -11,6 +11,7 @@ from edsdk import (
     Access,
     SaveTo,
     EdsObject,
+    PropertyEvent
 )
 
 if os.name == "nt":
@@ -62,7 +63,7 @@ if __name__ == "__main__":
     edsdk.SetPropertyData(cam, PropID.SaveTo, 0, SaveTo.Host)
     print(edsdk.GetPropertyData(cam, PropID.SaveTo))
 
-    # Sets HD Capacity to an arbitrary big value
+    # Sets (Computer's) Capacity to an arbitrary big value
     edsdk.SetCapacity(
         cam, {"reset": True, "bytesPerSector": 512, "numberOfFreeClusters": 2147483647}
     )


### PR DESCRIPTION
There is a missing import, `PropertyEvent` for the `callback_property` function (in the example)
There is no index set for the `GetPropertyData` (default doesn't work?)
As well as a better description for the `SetCapacity` function (in the example)

The term "Computer" was used as people can have both HDDs and SSDs so computer was a better pick.