### PR TITLE
🛠 Python 3.13 and above compatibility issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ You can comment out `Unknown` or rename it to `UNKNOWN` (or whatever you want) o
 
 ## Build the library
 
+
+> **⚠️ Note: This build requires Python 3.12 or earlier.** 
+> 
+> Build will fail under Python 3.13 and above because those versions removed the `PyEval_ThreadsInitialized()` function (deprecated since Python 3.9)
+
 Run:
 
 ```bash


### PR DESCRIPTION
## Summary

This pull request add a note for user to build this project using Python 3.12 or earlier.

---

Python deprecated the functions `PyEval_ThreadsInitialized()` in Python 3.9, and completely removed them in Python 3.13 

If you attempt to build the library using Python 3.13, you'll encounter an error like this:

```bash
  × Building wheel for edsdk-python (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [46 lines of output]                                                                                                                                                          
      C:\Users\JUSTIN PC\AppData\Local\Temp\pip-build-env-d7iv056b\overlay\Lib\site-packages\setuptools\dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!

              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: MIT License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
        self._finalize_license_expression()
      running bdist_wheel
      running build
      running build_py
      copying edsdk\__init__.py -> build\lib.win-amd64-cpython-313\edsdk
      copying edsdk\constants\commands.py -> build\lib.win-amd64-cpython-313\edsdk\constants
      copying edsdk\constants\generic.py -> build\lib.win-amd64-cpython-313\edsdk\constants
      copying edsdk\constants\properties.py -> build\lib.win-amd64-cpython-313\edsdk\constants
      copying edsdk\constants\__init__.py -> build\lib.win-amd64-cpython-313\edsdk\constants
      running egg_info
      writing edsdk_python.egg-info\PKG-INFO
      writing dependency_links to edsdk_python.egg-info\dependency_links.txt
      writing requirements to edsdk_python.egg-info\requires.txt
      writing top-level names to edsdk_python.egg-info\top_level.txt
      reading manifest file 'edsdk_python.egg-info\SOURCES.txt'
      adding license file 'LICENSE.md'
      writing manifest file 'edsdk_python.egg-info\SOURCES.txt'
      copying edsdk\api.pyi -> build\lib.win-amd64-cpython-313\edsdk
      copying edsdk\edsdk_python.cpp -> build\lib.win-amd64-cpython-313\edsdk
      copying edsdk\edsdk_python.h -> build\lib.win-amd64-cpython-313\edsdk
      copying edsdk\edsdk_utils.cpp -> build\lib.win-amd64-cpython-313\edsdk
      copying edsdk\edsdk_utils.h -> build\lib.win-amd64-cpython-313\edsdk
      copying edsdk\py.typed -> build\lib.win-amd64-cpython-313\edsdk
      running build_ext
      building 'edsdk.api' extension
      "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -Idependencies\EDSDK/Hea
der -IC:\Python313\include -IC:\Python313\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include" "-IC:\Program Files (x86)\Mic
rosoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\ucrt" "-IC:\Program Files (x86)\Windows Kits\10\\includ
e\10.0.26100.0\\um" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\shared" "-IC:\Program Files (x86)\Windows Kits\10\\include\10.0.26100.0\\winrt" "-IC:\Program F
iles (x86)\Windows Kits\10\\include\10.0.26100.0\\cppwinrt" "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um" /EHsc /Tpedsdk/edsdk_python.cpp /Fobuild\temp.win-amd64-cpython-313\Release\edsdk\edsdk_python.obj /W4 /DDEBUG=0
      cl : Command line warning D9025 : overriding '/W3' with '/W4'
      edsdk_python.cpp
      edsdk/edsdk_python.cpp(581): warning C4996: 'Py_FileSystemDefaultEncoding': deprecated in 3.12
      edsdk/edsdk_python.cpp(1295): warning C4996: 'Py_FileSystemDefaultEncoding': deprecated in 3.12
      edsdk/edsdk_python.cpp(1296): warning C4996: 'Py_FileSystemDefaultEncodeErrors': deprecated in 3.12
      edsdk/edsdk_python.cpp(2352): error C3861: 'PyEval_ThreadsInitialized': identifier not found
      edsdk/edsdk_python.cpp(2353): warning C4996: 'PyEval_InitThreads': deprecated in 3.9
      error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\VC\\Tools\\MSVC\\14.44.35207\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
      [end of output]                                                                                                                                                               

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for edsdk-python
Failed to build edsdk-python
ERROR: Failed to build installable wheels for some pyproject.toml based projects (edsdk-python)
```